### PR TITLE
[DO NOT MERGE] Debug assertion errors in CI

### DIFF
--- a/tools/concat_channels/concat_channels.xml
+++ b/tools/concat_channels/concat_channels.xml
@@ -57,18 +57,15 @@
             <param name="axis" value="0"/>
             <param name="mode" value="--preserve_values"/>
             <expand macro="tests/intensity_image_diff" name="output" value="res_preserve_values.tiff" ftype="tiff">
-                <!--
-
-                The input files have values ranging between 0 and 255.
-
-                Below, we use an assertion in addition to the `image_diff` comparison, to ensure that the range of
-                values is preserved. The motiviation behind this is that the expectation images are usually checked
-                visually, which means that the `image_diff` comparison is likely to ensure that the brightness of
-                the image is correct, thus it's good to double-check the range of values.
-
-                -->
                 <has_image_mean_intensity min="0" max="255"/>
             </expand>
+            <!--
+            <output name="output" value="res_preserve_values.tiff" ftype="tiff" compare="image_diff" metric="rms" eps="0.01">
+                <assert_contents>
+                    <has_image_mean_intensity min="0" max="255"/>
+                </assert_contents>
+            </output>
+            -->
         </test>
     </tests>
     <help>

--- a/tools/concat_channels/concat_channels.xml
+++ b/tools/concat_channels/concat_channels.xml
@@ -1,4 +1,4 @@
-<tool id="ip_concat_channels" name="Concatenate images or channels" version="0.3-1" profile="20.05">
+<tool id="ip_concat_channels" name="Concatenate images or channels" version="0.3-2" profile="20.05">
     <description></description>
     <macros>
         <import>creators.xml</import>


### PR DESCRIPTION
PLEASE DESCRIBE YOUR PR HERE

---

### Check-list for the contributor

Please make sure you have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2025/11/25).

**Mandatory checks:**

* [ ] License permits unrestricted use (educational + commercial).
* [ ] I agree to license these and all my past contributions to the Galaxy Image Analysis codebase under the [MIT license](https://github.com/BMCV/galaxy-image-analysis/blob/master/LICENSE.md).

**If this PR adds or updates a tool or tool collection:**

* [ ] This PR adds a new tool or tool collection.
* [ ] This PR updates an existing tool or tool collection.
* [ ] Tools added/updated by this PR comply with the Guidelines below (or explain why they do not).

### Guidelines for the contributor

<details>
<summary>
    This section is cited from the <a href="https://doi.org/10.37044/osf.io/w8dsz">Naming and Annotation Conventions for Tools in the Image Community in Galaxy</a>.
</summary>

<h4>Naming</h4>

Generally, the name of Galaxy tools in our community should be expressive and concise, while stating the purpose of the tool as precisely as possible. Consistency of the namings of Galaxy tools is important to ensure they can be found easily. To maintain consistency, we consider phrasing names as imperatives a good practice, such as "Analyze particles" or "Perform segmentation using watershed transformation". An acknowledged exception from this rule is the names of tool wrappers of major tool suites, where the name of a tool wrapper should be chosen identically to the module or function of the tool which is wrapped (e.g., "MaskImage" in CellProfiler).

<h4>Tool description</h4>

If a Galaxy tool is a thin tool wrapper (e.g, part of a major tool suite), then the name of the wrapped tool (and only the name of the wrapped tool, subsequent to the term "with" as in "with Bioformats") should be used as the description of the tool (further examples include "with CellProfiler", "with ImageJ2", "with ImageMagick", "with SpyBOAT", "with SuperDSM"). This ensures that the tool is found by typing the name of the wrapped tool into the "Search" field on the Galaxy interface. The tool description should be empty if a tool is either not part of a major tool suite, or the main functionality of the tool is implemented in the wrapper.

<h4>Annotations</h4>

We point out that there is a global list of precedential annotations with <a href="https://bio.tools">Bio.tools</a> identifiers (Ison et al., 2019) in Galaxy (see <a href="https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/ontologies/biotools_mappings.tsv">mappings</a>), which may outweigh the annotations made in the XML specification of a Galaxy tool (and thus the annotations of a tool reported within the web interface of Galaxy might be divergent). However, since the precedential annotations are subject to possible changes and to avoid redundant work, we do not aim to reflect those in our specifications (those which we make in the XML specifications of Galaxy tools).

</details>
